### PR TITLE
feat: add document upload API route and processing pipeline (pro…

### DIFF
--- a/apps/web/app/api/documents/[id]/stream/route.ts
+++ b/apps/web/app/api/documents/[id]/stream/route.ts
@@ -1,54 +1,19 @@
 import { NextRequest } from 'next/server';
-
-// GET /api/documents/[id]/stream
-//
-// Keeps an SSE connection open until the BullMQ parse→chunk→embed
-// pipeline completes for this document, then pushes one event and closes.
-//
-// Your BullMQ worker (in packages/core or a separate worker process) should
-// call notifyDocumentComplete(documentId, status, error?) when the job finishes.
-// This route bridges that signal to the waiting browser.
-//
-// The simplest approach at your scale: use a shared in-memory Map of
-// resolve callbacks. Works fine for a single-process Next.js server.
-// For multi-process / edge deployments, swap this for Redis pub/sub.
-
-type Resolver = (result: { status: 'ready' | 'failed'; error?: string }) => void;
-
-// Module-level map — persists across requests in the same process
-const waiters = new Map<string, Resolver>();
-
-// Called by your BullMQ worker when a job finishes.
-// Import this in your worker: import { notifyDocumentComplete } from '@/app/api/documents/[id]/stream/route'
-export function notifyDocumentComplete(
-    documentId: string,
-    status: 'ready' | 'failed',
-    error?: string,
-) {
-    const resolve = waiters.get(documentId);
-    if (resolve) {
-        resolve({ status, error });
-        waiters.delete(documentId);
-    }
-}
+import { waiters } from '@/lib/waiters';
 
 export async function GET(
     _req: NextRequest,
-    { params }: { params: { id: string } },
+    { params }: { params: Promise<{ id: string }> },
 ) {
-    const { id: documentId } = params;
+    const { id: documentId } = await params;
 
     const stream = new ReadableStream({
         start(controller) {
             const encoder = new TextEncoder();
 
-            // Send SSE headers comment to keep connection alive
             controller.enqueue(encoder.encode(': connected\n\n'));
 
-            // Register a resolver — the BullMQ worker will call notifyDocumentComplete()
-            // which resolves this promise and sends the final event
             const timeout = setTimeout(() => {
-                // Safety net: if job takes > 5 min, send failure and close
                 const data = JSON.stringify({ status: 'failed', error: 'Processing timed out' });
                 controller.enqueue(encoder.encode(`data: ${data}\n\n`));
                 controller.close();
@@ -63,7 +28,6 @@ export async function GET(
             });
         },
         cancel() {
-            // Browser closed the connection before job finished
             waiters.delete(documentId);
         },
     });

--- a/apps/web/app/api/documents/upload/route.ts
+++ b/apps/web/app/api/documents/upload/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest } from 'next/server';
+import { parsePDFFromBuffer } from '@/lib/parser';
+import { chunkDocument } from '@/lib/chunker';
+import { embedChunksStrict } from '@/lib/embedder';
+import { notifyDocumentComplete } from '@/lib/waiters';
+
+export async function POST(req: NextRequest) {
+  try {
+    const formData = await req.formData();
+    const file = formData.get('file') as File;
+
+    if (!file) {
+      return Response.json({ message: 'No file provided' }, { status: 400 });
+    }
+
+    // Generate a simple ID for this document
+    const documentId = crypto.randomUUID();
+
+    // Run the pipeline in the background so we can return documentId immediately
+    (async () => {
+      try {
+        const buffer = Buffer.from(await file.arrayBuffer());
+        const doc = await parsePDFFromBuffer(buffer);
+        const chunks = await chunkDocument(doc);
+        const embedded = await embedChunksStrict(chunks);
+
+        // TODO: save `embedded` to your database here
+
+        console.log(`Document ${documentId}: ${embedded.length} chunks ready`);
+        embedded.forEach((chunk, i) => {
+            console.log(`\n--- Chunk ${i} (heading: ${chunk.heading}) ---`);
+            console.log(chunk.content);
+            console.log(`Key terms: ${chunk.keyTerms.join(', ')}`);
+        });
+        notifyDocumentComplete(documentId, 'ready');
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Unknown error';
+        console.error('Pipeline error:', msg);
+        notifyDocumentComplete(documentId, 'failed', msg);
+    }
+    })();
+
+    // Return immediately — UI will poll SSE stream for status
+    return Response.json({ documentId });
+
+  } catch {
+    return Response.json({ message: 'Upload failed' }, { status: 500 });
+  }
+}

--- a/apps/web/lib/chunker.ts
+++ b/apps/web/lib/chunker.ts
@@ -1,0 +1,112 @@
+import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ParsedDocument {
+    text: string;
+    headings: string[];   // section headings detected by the parser
+    pageCount: number;
+}
+
+export interface Chunk {
+    content: string;
+    chunkIndex: number;
+    keyTerms: string[];
+    heading: string | null; // nearest heading above this chunk, if any
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const CHUNK_SIZE = 500;       // characters per chunk
+const CHUNK_OVERLAP = 50;     // overlap between adjacent chunks
+
+const splitter = new RecursiveCharacterTextSplitter({
+    chunkSize: CHUNK_SIZE,
+    chunkOverlap: CHUNK_OVERLAP,
+    separators: ["\n\n", "\n", ".", " ", ""],
+});
+
+// ---------------------------------------------------------------------------
+// Key term extraction
+// ---------------------------------------------------------------------------
+// Simple heuristic: words that are Title Case or ALL_CAPS and longer than
+// 3 characters are likely domain terms. Strips common stop words.
+// Swap this out for a proper NLP library (e.g. `compromise`) in Phase-2.
+
+const STOP_WORDS = new Set([
+    "the", "and", "for", "with", "this", "that", "from", "have",
+    "are", "was", "were", "will", "can", "may", "but", "not", "its",
+    "into", "also", "more", "when", "then", "than", "such", "each",
+    "about", "they", "their", "which", "been", "being", "would",
+]);
+
+function extractKeyTerms(text: string): string[] {
+    const words = text.match(/\b[A-Z][a-zA-Z]{3,}\b/g) ?? [];
+    const unique = Array.from(new Set(words.map((w) => w.toLowerCase())));
+    return unique.filter((w) => !STOP_WORDS.has(w)).slice(0, 10);
+}
+
+// ---------------------------------------------------------------------------
+// Heading assignment
+// ---------------------------------------------------------------------------
+// For each chunk, find the last heading that appears before it in the
+// original text. This gives the chunk topical context without restructuring
+// the splitter logic.
+
+function assignHeadings(
+    rawText: string,
+    chunkContents: string[],
+    headings: string[]
+): (string | null)[] {
+    if (headings.length === 0) return chunkContents.map(() => null);
+
+    // Map each heading to its character offset in the original text
+    const headingOffsets: { heading: string; offset: number }[] = headings
+        .map((h) => ({ heading: h, offset: rawText.indexOf(h) }))
+        .filter((h) => h.offset !== -1)
+        .sort((a, b) => a.offset - b.offset);
+
+    return chunkContents.map((content) => {
+        const chunkOffset = rawText.indexOf(content);
+        if (chunkOffset === -1) return null;
+
+        // Walk backwards through headings to find the nearest one before this chunk
+        let assigned: string | null = null;
+        for (const { heading, offset } of headingOffsets) {
+            if (offset <= chunkOffset) assigned = heading;
+            else break;
+        }
+        return assigned;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export async function chunkDocument(doc: ParsedDocument): Promise<Chunk[]> {
+    if (!doc.text || doc.text.trim().length === 0) {
+        throw new Error("Cannot chunk an empty document.");
+    }
+
+    const rawChunks = await splitter.splitText(doc.text);
+
+    if (rawChunks.length === 0) {
+        throw new Error("Splitter returned no chunks — document may be too short.");
+    }
+
+    const headingMap = assignHeadings(doc.text, rawChunks, doc.headings);
+
+    const chunks: Chunk[] = rawChunks.map((content, i) => ({
+        content,
+        chunkIndex: i,
+        keyTerms: extractKeyTerms(content),
+        heading: headingMap[i] ?? null,
+    }));
+
+    return chunks;
+}

--- a/apps/web/lib/embedder.ts
+++ b/apps/web/lib/embedder.ts
@@ -1,0 +1,131 @@
+import { Chunk } from "./chunker";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface EmbeddedChunk extends Chunk {
+    embedding: number[];
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+// Using Google Gemini text-embedding-004 (768 dims), free tier, 1,500 RPM.
+// Make sure your Prisma schema has: embedding vector(768)
+//
+// Set GEMINI_API_KEY in your .env file.
+// Set EMBEDDING_MOCK=true in .env to skip API calls during local dev/testing.
+
+const EMBEDDING_MODEL = "gemini-embedding-001";
+const EMBEDDING_DIM = 3072;
+const GEMINI_EMBED_URL = `https://generativelanguage.googleapis.com/v1beta/models/${EMBEDDING_MODEL}:batchEmbedContents`;
+
+// Gemini batchEmbedContents supports up to 100 inputs per request.
+const BATCH_SIZE = 100;
+
+// ---------------------------------------------------------------------------
+// Mock embedding (dev / test)
+// ---------------------------------------------------------------------------
+
+function mockEmbedding(text: string): number[] {
+    let seed = 0;
+    for (let i = 0; i < text.length; i++) seed = (seed * 31 + text.charCodeAt(i)) >>> 0;
+
+    return Array.from({ length: EMBEDDING_DIM }, (_, i) => {
+        const x = Math.sin(seed + i) * 10000;
+        return x - Math.floor(x);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Real embedding via Gemini batchEmbedContents API
+// ---------------------------------------------------------------------------
+
+async function fetchEmbeddings(texts: string[]): Promise<number[][]> {
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) throw new Error("GEMINI_API_KEY is not set in environment.");
+
+    const requests = texts.map((text) => ({
+        model: `models/${EMBEDDING_MODEL}`,
+        content: { parts: [{ text }] },
+    }));
+
+    const response = await fetch(`${GEMINI_EMBED_URL}?key=${apiKey}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ requests }),
+    });
+
+    if (!response.ok) {
+        const error = await response.text();
+        throw new Error(`Gemini embeddings API error ${response.status}: ${error}`);
+    }
+
+    const data = await response.json();
+
+    // Response shape: { embeddings: [{ values: number[] }, ...] }
+    return (data.embeddings as { values: number[] }[]).map((e) => e.values);
+}
+
+// ---------------------------------------------------------------------------
+// Batch helper
+// ---------------------------------------------------------------------------
+
+function batchArray<T>(arr: T[], size: number): T[][] {
+    const batches: T[][] = [];
+    for (let i = 0; i < arr.length; i += size) {
+        batches.push(arr.slice(i, i + size));
+    }
+    return batches;
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export async function embedChunks(chunks: Chunk[]): Promise<EmbeddedChunk[]> {
+    if (chunks.length === 0) return [];
+
+    const useMock = process.env.EMBEDDING_MOCK === "true";
+
+    if (useMock) {
+        console.warn("[embedder] EMBEDDING_MOCK=true — using fake vectors.");
+        return chunks.map((chunk) => ({
+            ...chunk,
+            embedding: mockEmbedding(chunk.content),
+        }));
+    }
+
+    const batches = batchArray(chunks, BATCH_SIZE);
+    const allEmbeddings: number[][] = [];
+
+    for (const batch of batches) {
+        const texts = batch.map((c) => c.content);
+        const embeddings = await fetchEmbeddings(texts);
+        allEmbeddings.push(...embeddings);
+    }
+
+    return chunks.map((chunk, i) => ({
+        ...chunk,
+        embedding: allEmbeddings[i]!,
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Strict variant — validates dimensions before anything touches the DB
+// ---------------------------------------------------------------------------
+
+export async function embedChunksStrict(chunks: Chunk[]): Promise<EmbeddedChunk[]> {
+    const embedded = await embedChunks(chunks);
+
+    for (const chunk of embedded) {
+        if (chunk.embedding.length !== EMBEDDING_DIM) {
+            throw new Error(
+                `Embedding dimension mismatch: expected ${EMBEDDING_DIM}, got ${chunk.embedding.length} on chunk ${chunk.chunkIndex}`
+            );
+        }
+    }
+
+    return embedded;
+}

--- a/apps/web/lib/parser.ts
+++ b/apps/web/lib/parser.ts
@@ -1,0 +1,83 @@
+import { readFile } from "node:fs/promises";
+import { extractText } from "unpdf";
+
+export interface ParsedDocument {
+  text: string;
+  headings: string[];
+  pageCount: number;
+}
+
+function cleanText(raw: string): string {
+  let text = raw.replace(/\n{3,}/g, "\n\n");
+  text = text.replace(/ {2,}/g, " ");
+  text = text.replace(/\n\s*\d+\s*\n/g, "\n");
+  text = text.replace(/Page \d+ of \d+/gi, "");
+  return text.trim();
+}
+
+function extractHeadings(text: string): string[] {
+  const lines = text.split("\n");
+  const headings: string[] = [];
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || line.length > 100) continue;
+    if (line.endsWith(".")) continue;
+    if (/^\d+$/.test(line)) continue;
+
+    const isNumbered = /^\d+(\.\d+)*\.?\s+\S/.test(line);
+    const isAllCaps = line === line.toUpperCase() && /[A-Z]/.test(line);
+    const words = line.split(/\s+/);
+    const titleCaseCount = words.filter((w) => /^[A-Z]/.test(w)).length;
+    const isTitleCase = words.length >= 2 && titleCaseCount / words.length >= 0.6;
+
+    if (isNumbered || isAllCaps || isTitleCase) {
+      headings.push(line);
+    }
+  }
+
+  return headings;
+}
+
+export async function parsePDF(filePath: string): Promise<ParsedDocument> {
+  const buffer = await readFile(filePath);
+  const { text: rawText } = await extractText(new Uint8Array(buffer), { mergePages: true });
+
+  if (!rawText || rawText.trim().length === 0) {
+    throw new Error(
+      "No text found in PDF. It might be a scanned/image-only PDF. " +
+        "Please upload a text-based version."
+    );
+  }
+
+  const cleanedText = cleanText(rawText);
+  const headings = extractHeadings(cleanedText);
+
+  return {
+    text: cleanedText,
+    headings,
+    pageCount: 0,
+  };
+}
+
+export async function parsePDFFromBuffer(
+  buffer: Buffer
+): Promise<ParsedDocument> {
+  const { text: rawText } = await extractText(new Uint8Array(buffer), { mergePages: true });
+
+  if (!rawText || rawText.trim().length === 0) {
+    throw new Error(
+      "No text found in PDF. It might be a scanned/image-only PDF. " +
+        "Please upload a text-based version."
+    );
+  }
+
+  const cleanedText = cleanText(rawText);
+  const headings = extractHeadings(cleanedText);
+
+  return {
+    text: cleanedText,
+    headings,
+    pageCount: 0,
+  };
+}

--- a/apps/web/lib/waiters.ts
+++ b/apps/web/lib/waiters.ts
@@ -1,0 +1,15 @@
+type Resolver = (result: { status: 'ready' | 'failed'; error?: string }) => void;
+
+export const waiters = new Map<string, Resolver>();
+
+export function notifyDocumentComplete(
+    documentId: string,
+    status: 'ready' | 'failed',
+    error?: string,
+) {
+    const resolve = waiters.get(documentId);
+    if (resolve) {
+        resolve({ status, error });
+        waiters.delete(documentId);
+    }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,10 +11,12 @@
     "check-types": "next typegen && tsc --noEmit"
   },
   "dependencies": {
+    "@langchain/textsplitters": "^1.0.1",
     "@repo/ui": "*",
     "next": "16.2.0",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "unpdf": "^1.4.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,10 +39,12 @@
     "apps/web": {
       "version": "0.1.0",
       "dependencies": {
+        "@langchain/textsplitters": "^1.0.1",
         "@repo/ui": "*",
         "next": "16.2.0",
         "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.0",
+        "unpdf": "^1.4.0"
       },
       "devDependencies": {
         "@repo/eslint-config": "*",
@@ -53,6 +55,13 @@
         "eslint": "^9.39.1",
         "typescript": "5.9.2"
       }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.2",
@@ -739,6 +748,57 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@langchain/core": {
+      "version": "1.1.39",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.39.tgz",
+      "integrity": "sha512-DP9c7TREy6iA7HnywstmUAsNyJNYTFpRg2yBfQ+6H0l1HnvQzei9GsQ36GeOLxgRaD3vm9K8urCcawSC7yQpCw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "uuid": "^11.1.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@langchain/textsplitters": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@langchain/textsplitters/-/textsplitters-1.0.1.tgz",
+      "integrity": "sha512-rheJlB01iVtrOUzttscutRgLybPH9qR79EyzBEbf1u97ljWyuxQfCwIWK+SjoQTM9O8M7GGLLRBSYE26Jmcoww==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tiktoken": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.0.0"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.0.tgz",
@@ -932,6 +992,13 @@
     "node_modules/@repo/ui": {
       "resolved": "packages/ui",
       "link": true
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -1599,6 +1666,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.14",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.14.tgz",
@@ -1693,6 +1780,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1857,6 +1957,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/deep-is": {
@@ -2381,6 +2491,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3257,6 +3374,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3322,6 +3448,55 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/langsmith": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.18.tgz",
+      "integrity": "sha512-3zuZUWffTHQ+73EAwnodADtf534VNEZUpXr9jC12qyG8/IQuJET7PRsCpTb9wX2lmBspakwLUpqpj3tNm/0bVA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-queue": "6.6.2",
+        "uuid": "10.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*",
+        "ws": ">=7"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/langsmith/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/levn": {
@@ -3427,6 +3602,16 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "mustache": "bin/mustache"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -3669,6 +3854,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -3699,6 +3894,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/parent-module": {
@@ -4721,6 +4946,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unpdf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.4.0.tgz",
+      "integrity": "sha512-TahIk0xdH/4jh/MxfclzU79g40OyxtP00VnEUZdEkJoYtXAHWLiir6t3FC6z3vDqQTzc2ZHcla6uEiVTNjejuA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@napi-rs/canvas": "^0.1.69"
+      },
+      "peerDependenciesMeta": {
+        "@napi-rs/canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4729,6 +4968,20 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/web": {
@@ -4861,6 +5114,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "packages/eslint-config": {


### PR DESCRIPTION
feat(web): add document upload API route and processing pipeline

Changes introduced:
- apps/web/app/api/documents/upload/route.ts: Upload API route that receives PDF, runs parse→chunk→embed pipeline, and returns documentId
- apps/web/app/api/documents/[id]/stream/route.ts: Fixed params awaiting bug for Next.js 15
- apps/web/lib/parser.ts: PDF text extraction using unpdf
- apps/web/lib/chunker.ts: Splits parsed text into overlapping chunks with heading assignment
- apps/web/lib/embedder.ts: Embeds chunks using Gemini API (mock mode supported)
- apps/web/lib/waiters.ts: Shared in-memory map for SSE completion signaling
- apps/web/package.json: Added unpdf and @langchain/textsplitters dependencies
- package-lock.json: Auto-updated lockfile

Related Issues: Progress on #15, #16