### PR TITLE
feat: Socrati chat page UI

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1,0 +1,32 @@
+export async function POST(req: Request) {
+    const { messages } = await req.json();
+
+    // Check if this is the first interaction
+    const isFirstMessage = !messages || messages.length === 0;
+    
+    const mockResponseText = isFirstMessage 
+        ? "I've looked through your uploaded material. Before we dive in — what topic feels least solid to you right now?"
+        : "That's an interesting perspective! To help me understand your thought process better, how does that connect back to the main themes in the document?";
+
+    // Create a native ReadableStream to simulate a typing effect
+    const stream = new ReadableStream({
+        async start(controller) {
+            const encoder = new TextEncoder();
+            const words = mockResponseText.split(' ');
+            
+            for (const word of words) {
+                // Send the word plus a space
+                controller.enqueue(encoder.encode(word + ' '));
+                // Wait 50ms to simulate the AI "thinking" and streaming
+                await new Promise(resolve => setTimeout(resolve, 50));
+            }
+            controller.close();
+        }
+    });
+
+    return new Response(stream, {
+        headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+        }
+    });
+}

--- a/apps/web/app/sessions/[sessionId]/page.tsx
+++ b/apps/web/app/sessions/[sessionId]/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
 import Sidebar from '@/components/Sidebar';
+import { ChatContainer } from '@/components/chat/ChatContainer';
 
 type SessionDocument = {
     document_id: string;
@@ -142,45 +143,21 @@ export default function SessionPage() {
                     </div>
 
                     {/* Chat area */}
-                    <div
-                        style={{
-                            flex: 1,
-                            display: 'flex',
-                            flexDirection: 'column',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            padding: '20px 24px',
-                            gap: 12,
-                            color: 'var(--t3)',
-                        }}
-                    >
-                        {!loading && !error && session && (
-                            <>
-                                <div style={{ fontSize: 28 }}>📚</div>
-                                <div
-                                    style={{
-                                        fontSize: 15,
-                                        fontWeight: 500,
-                                        color: 'var(--td)',
-                                    }}
-                                >
-                                    Ready to study
-                                </div>
-                                <div
-                                    style={{
-                                        fontSize: 13,
-                                        textAlign: 'center',
-                                        maxWidth: 320,
-                                        lineHeight: 1.5,
-                                    }}
-                                >
-                                    Your session is set up with {docCount} document
-                                    {docCount !== 1 ? 's' : ''}. AI tutoring will
-                                    appear here.
-                                </div>
-                            </>
-                        )}
-                    </div>
+                    {!loading && !error && session ? (
+                        <ChatContainer sessionId={sessionId} />
+                    ) : (
+                        <div
+                            style={{
+                                flex: 1,
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                color: 'var(--t3)',
+                            }}
+                        >
+                            {loading ? 'Loading...' : error ? error : ''}
+                        </div>
+                    )}
                 </div>
             </main>
         </div>

--- a/apps/web/components/chat/ChatContainer.tsx
+++ b/apps/web/components/chat/ChatContainer.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ChatMessage } from './ChatMessage';
 import { ChatInput } from './ChatInput';
 
 export function ChatContainer({ sessionId }: { sessionId: string }) {
-    const { messages, input, handleInputChange, handleSubmit, setInput, isLoading } = useChat({
+    const [input, setInput] = useState('');
+
+    const { messages, sendMessage, status } = useChat({
         api: '/api/chat',
         body: { sessionId },
         initialMessages: [
@@ -17,13 +19,26 @@ export function ChatContainer({ sessionId }: { sessionId: string }) {
             }
         ]
     });
-    
+
+    const isLoading = status === 'submitted' || status === 'streaming';
     const bottomRef = useRef<HTMLDivElement>(null);
 
     // Auto-scroll to bottom on new messages
     useEffect(() => {
         bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
     }, [messages]);
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setInput(e.target.value);
+    };
+
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (!input.trim() || isLoading) return;
+        // The newest Vercel AI SDK uses 'sendMessage' instead of 'append' or 'handleSubmit'!
+        sendMessage({ role: 'user', content: input.trim() });
+        setInput('');
+    };
 
     return (
         <div style={{
@@ -65,19 +80,19 @@ export function ChatContainer({ sessionId }: { sessionId: string }) {
                 flexDirection: 'column',
                 gap: 16,
             }}>
-                {messages.map((msg) => (
+                {messages?.map((msg: any) => (
                     <ChatMessage key={msg.id} message={msg} />
                 ))}
-                
-                {isLoading && messages[messages.length - 1]?.role === 'user' && (
+
+                {isLoading && messages?.[messages.length - 1]?.role === 'user' && (
                     <div style={{ fontSize: 13, color: 'var(--t3)', marginLeft: 8 }}>Thinking...</div>
                 )}
-                
+
                 <div ref={bottomRef} />
             </div>
 
             {/* Input Area */}
-            <ChatInput 
+            <ChatInput
                 input={input}
                 handleInputChange={handleInputChange}
                 handleSubmit={handleSubmit}

--- a/apps/web/components/chat/ChatContainer.tsx
+++ b/apps/web/components/chat/ChatContainer.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { useEffect, useRef } from 'react';
+import { ChatMessage } from './ChatMessage';
+import { ChatInput } from './ChatInput';
+
+export function ChatContainer({ sessionId }: { sessionId: string }) {
+    const { messages, input, handleInputChange, handleSubmit, setInput, isLoading } = useChat({
+        api: '/api/chat',
+        body: { sessionId },
+        initialMessages: [
+            {
+                id: 'opening-msg',
+                role: 'assistant',
+                content: "I've looked through your uploaded material. Before we dive in — what topic feels least solid to you right now?"
+            }
+        ]
+    });
+    
+    const bottomRef = useRef<HTMLDivElement>(null);
+
+    // Auto-scroll to bottom on new messages
+    useEffect(() => {
+        bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }, [messages]);
+
+    return (
+        <div style={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+        }}>
+            {/* Header bar from your prototype */}
+            <div style={{
+                padding: '14px 24px',
+                borderBottom: '1px solid var(--b1)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+                background: 'var(--main)',
+                flexShrink: 0,
+            }}>
+                <div style={{ fontSize: 14, fontWeight: 500, color: 'var(--td)' }}>
+                    Tutoring Session
+                </div>
+                <div style={{
+                    fontSize: 11,
+                    color: 'var(--t3)',
+                    background: 'var(--acl)',
+                    padding: '2px 10px',
+                    borderRadius: 99,
+                }}>
+                    Socratic mode
+                </div>
+            </div>
+
+            {/* Messages Area */}
+            <div style={{
+                flex: 1,
+                overflowY: 'auto',
+                padding: '24px',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 16,
+            }}>
+                {messages.map((msg) => (
+                    <ChatMessage key={msg.id} message={msg} />
+                ))}
+                
+                {isLoading && messages[messages.length - 1]?.role === 'user' && (
+                    <div style={{ fontSize: 13, color: 'var(--t3)', marginLeft: 8 }}>Thinking...</div>
+                )}
+                
+                <div ref={bottomRef} />
+            </div>
+
+            {/* Input Area */}
+            <ChatInput 
+                input={input}
+                handleInputChange={handleInputChange}
+                handleSubmit={handleSubmit}
+                setInput={setInput}
+                isLoading={isLoading}
+            />
+        </div>
+    );
+}

--- a/apps/web/components/chat/ChatInput.tsx
+++ b/apps/web/components/chat/ChatInput.tsx
@@ -1,0 +1,112 @@
+import { useRef, useEffect } from 'react';
+
+interface ChatInputProps {
+    input: string;
+    handleInputChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+    handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+    setInput: (value: string) => void;
+    isLoading: boolean;
+}
+
+export function ChatInput({ input, handleInputChange, handleSubmit, setInput, isLoading }: ChatInputProps) {
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    // Auto-resize textarea logic from your prototype
+    useEffect(() => {
+        const ta = textareaRef.current;
+        if (!ta) return;
+        ta.style.height = 'auto';
+        ta.style.height = Math.min(ta.scrollHeight, 140) + 'px';
+    }, [input]);
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            // Programmatically submit the form when Enter is pressed
+            const form = e.currentTarget.form;
+            if (form) form.requestSubmit();
+        }
+    };
+
+    return (
+        <div style={{ padding: '0 24px 20px', flexShrink: 0 }}>
+            {/* Hint bar from your prototype */}
+            <div style={{ display: 'flex', gap: 8, marginBottom: 8, overflowX: 'auto' }}>
+                {['give me a hint', "I don't understand", 'can you rephrase that'].map(hint => (
+                    <button
+                        key={hint}
+                        onClick={() => { setInput(hint); textareaRef.current?.focus(); }}
+                        type="button"
+                        style={{
+                            fontSize: 11,
+                            color: 'var(--t2)',
+                            background: 'var(--card)',
+                            border: '1px solid var(--b1)',
+                            borderRadius: 99,
+                            padding: '4px 12px',
+                            cursor: 'pointer',
+                            fontFamily: 'inherit',
+                            whiteSpace: 'nowrap',
+                        }}
+                    >
+                        {hint}
+                    </button>
+                ))}
+            </div>
+
+            <form onSubmit={handleSubmit} style={{
+                display: 'flex',
+                alignItems: 'flex-end',
+                gap: 10,
+                background: 'var(--card)',
+                border: '1px solid var(--b1)',
+                borderRadius: 14,
+                padding: '10px 12px 10px 16px',
+            }}>
+                <textarea
+                    ref={textareaRef}
+                    value={input}
+                    onChange={handleInputChange}
+                    onKeyDown={handleKeyDown}
+                    placeholder="Your answer..."
+                    rows={1}
+                    style={{
+                        flex: 1,
+                        border: 'none',
+                        outline: 'none',
+                        resize: 'none',
+                        fontFamily: 'inherit',
+                        fontSize: 14,
+                        color: 'var(--td)',
+                        background: 'transparent',
+                        lineHeight: '1.5',
+                    }}
+                />
+                <button
+                    type="submit"
+                    disabled={!input.trim() || isLoading}
+                    style={{
+                        width: 34,
+                        height: 34,
+                        borderRadius: 9,
+                        border: 'none',
+                        background: input.trim() && !isLoading ? 'var(--acc)' : 'var(--b1)',
+                        cursor: input.trim() && !isLoading ? 'pointer' : 'default',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        flexShrink: 0,
+                        transition: 'background 0.15s',
+                    }}
+                >
+                    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                        <path d="M2 7h10M8 3l4 4-4 4" stroke="white" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                </button>
+            </form>
+            <div style={{ fontSize: 10, color: 'var(--t3)', marginTop: 6, textAlign: 'center' }}>
+                Press Enter to send · Shift+Enter for new line
+            </div>
+        </div>
+    );
+}

--- a/apps/web/components/chat/ChatInput.tsx
+++ b/apps/web/components/chat/ChatInput.tsx
@@ -84,14 +84,14 @@ export function ChatInput({ input, handleInputChange, handleSubmit, setInput, is
                 />
                 <button
                     type="submit"
-                    disabled={!input.trim() || isLoading}
+                    disabled={!input?.trim() || isLoading}
                     style={{
                         width: 34,
                         height: 34,
                         borderRadius: 9,
                         border: 'none',
-                        background: input.trim() && !isLoading ? 'var(--acc)' : 'var(--b1)',
-                        cursor: input.trim() && !isLoading ? 'pointer' : 'default',
+                        background: input?.trim() && !isLoading ? 'var(--acc)' : 'var(--b1)',
+                        cursor: input?.trim() && !isLoading ? 'pointer' : 'default',
                         display: 'flex',
                         alignItems: 'center',
                         justifyContent: 'center',

--- a/apps/web/components/chat/ChatMessage.tsx
+++ b/apps/web/components/chat/ChatMessage.tsx
@@ -1,0 +1,26 @@
+import type { Message } from '@ai-sdk/react';
+
+export function ChatMessage({ message }: { message: Message }) {
+    const isUser = message.role === 'user';
+    
+    return (
+        <div style={{
+            display: 'flex',
+            justifyContent: isUser ? 'flex-end' : 'flex-start',
+        }}>
+            <div style={{
+                maxWidth: '70%',
+                padding: '11px 15px',
+                borderRadius: isUser ? '14px 14px 4px 14px' : '14px 14px 14px 4px',
+                background: isUser ? 'var(--acc)' : 'var(--card)',
+                border: isUser ? 'none' : '1px solid var(--b1)',
+                fontSize: 14,
+                lineHeight: '1.6',
+                color: isUser ? '#eef8f2' : 'var(--td)',
+                whiteSpace: 'pre-wrap',
+            }}>
+                {message.content}
+            </div>
+        </div>
+    );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,10 +13,12 @@
     "check-types": "next typegen && tsc --noEmit"
   },
   "dependencies": {
+    "@ai-sdk/react": "^3.0.179",
     "@langchain/textsplitters": "^1.0.1",
     "@repo/ui": "*",
     "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.105.3",
+    "ai": "^6.0.177",
     "bullmq": "^5.76.6",
     "ioredis": "^5.10.1",
     "next": "16.2.0",

--- a/apps/web/scripts/dev.ts
+++ b/apps/web/scripts/dev.ts
@@ -1,6 +1,9 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { loadEnvFiles } from '../lib/load-env.js';
+
+loadEnvFiles();
 
 const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,10 +39,12 @@
     "apps/web": {
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/react": "^3.0.179",
         "@langchain/textsplitters": "^1.0.1",
         "@repo/ui": "*",
         "@supabase/ssr": "^0.10.3",
         "@supabase/supabase-js": "^2.105.3",
+        "ai": "^6.0.177",
         "bullmq": "^5.76.6",
         "ioredis": "^5.10.1",
         "next": "16.2.0",
@@ -61,6 +63,70 @@
         "eslint": "^9.39.1",
         "tsx": "^4.21.0",
         "typescript": "5.9.2"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.112",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.112.tgz",
+      "integrity": "sha512-jiBao9pR4owWyjo0BnuNc7WSQBGOD0thysE4AFgZXaG+zMFbISQXUkJr7ePw/phBvePy7jE5FSA2Lf7lwqUiiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "3.0.179",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.179.tgz",
+      "integrity": "sha512-wq3gqDrwi6QvwHQuVrTpjeUQI/LHZ5ysokWTIS1hOFw0UIIX8eVpri5iVvqQuq5CeQw/6bYXSI15SfMtZJixpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "4.0.27",
+        "ai": "6.0.177",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
       }
     },
     "node_modules/@cfworker/json-schema": {
@@ -1514,6 +1580,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@repo/eslint-config": {
       "resolved": "packages/eslint-config",
       "link": true
@@ -1526,12 +1601,15 @@
       "resolved": "packages/ui",
       "link": true
     },
+    "node_modules/@socrati/core": {
+      "resolved": "packages/core",
+      "link": true
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.105.3",
@@ -2071,6 +2149,15 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2092,6 +2179,24 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.177",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.177.tgz",
+      "integrity": "sha512-1xQtbeWwNcLyyM86ixZhkKvT+WRXc1lvarIKqPVtsyn8F9NDikwUMBqYu+aQKDgMht50SMXh4qboYuU8MeHZZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.112",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -2722,6 +2827,15 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3250,6 +3364,15 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4222,6 +4345,12 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -5615,6 +5744,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5911,6 +6065,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
@@ -6085,6 +6248,13 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "packages/core": {
+      "name": "@socrati/core",
+      "version": "0.1.0",
+      "dependencies": {
+        "@langchain/textsplitters": "^1.0.1"
       }
     },
     "packages/eslint-config": {

--- a/tests/chat-api.test.ts
+++ b/tests/chat-api.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { POST } from '../apps/web/app/api/chat/route';
+
+// Helper to construct a mock POST request
+function makeRequest(body: unknown): Request {
+    return new Request('http://localhost/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+}
+
+// Helper to read the ReadableStream from the response into a single string
+async function readStreamToString(stream: ReadableStream<Uint8Array> | null): Promise<string> {
+    if (!stream) return '';
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let result = '';
+    
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        result += decoder.decode(value);
+    }
+    
+    return result.trim(); // Trim any trailing spaces from the chunked stream
+}
+
+describe('POST /api/chat', () => {
+    it('returns the mock Socratic opening question when message history is empty', async () => {
+        const req = makeRequest({ messages: [] });
+        const res = await POST(req);
+
+        assert.equal(res.status, 200);
+        assert.equal(res.headers.get('Content-Type'), 'text/plain; charset=utf-8');
+
+        const text = await readStreamToString(res.body);
+        assert.equal(
+            text, 
+            "I've looked through your uploaded material. Before we dive in — what topic feels least solid to you right now?"
+        );
+    });
+
+    it('returns the generic mock response when message history has existing messages', async () => {
+        const req = makeRequest({ messages: [{ role: 'user', content: 'I need a hint.' }] });
+        const res = await POST(req);
+
+        assert.equal(res.status, 200);
+
+        const text = await readStreamToString(res.body);
+        assert.equal(
+            text,
+            "That's an interesting perspective! To help me understand your thought process better, how does that connect back to the main themes in the document?"
+        );
+    });
+});


### PR DESCRIPTION
This PR introduces the core AI Socratic tutor chat interface, utilizing the Vercel AI SDK to handle real-time streaming, optimistic UI updates, and message history state. It strictly prepares the frontend architecture for the upcoming real LLM integration.

Changes introduced:
- **apps/web/scripts/dev.ts**: Fixed a critical monorepo environment variable bug by injecting root `.env.local` keys into the Next.js process via `loadEnvFiles()`.  
- **apps/web/package.json**: Installed the `ai` and `@ai-sdk/react` packages to support the chat streaming hooks.  
- **apps/web/app/api/chat/route.ts**: Created a temporary mock streaming API endpoint designed to test the initial UI structure. *(Note: Currently silent as the frontend has been upgraded to expect the strict AI SDK Data Stream protocol in preparation for Phase 3).*  
- **apps/web/components/chat/ChatContainer.tsx**: Built the parent chat component wrapping the `useChat` hook. Upgraded to use the cutting-edge `sendMessage` and `status` API, and implemented a "Dual-State Pattern" so the custom Hint shortcut buttons seamlessly interact with the SDK's internal state.  
- **apps/web/components/chat/ChatInput.tsx**: Built the input area featuring an auto-resizing text area, clickable hint shortcut buttons, and an optional-chaining safeguard to prevent React hydration crashes.  
- **apps/web/components/chat/ChatMessage.tsx**: Built the individual chat bubble components with distinct styling for the user and the assistant.  
- **apps/web/app/sessions/[sessionId]/page.tsx**: Wired the new `ChatContainer` into the session view, replacing the temporary "Ready to study" placeholder.  
- **tests/chat-api.test.ts**: Added backend test coverage to verify that the mock empty-history and populated-history response streams function correctly.  

Related Issues: Fixes #25