### PR TITLE
feat: implement RAG retrieval pipeline with vector search

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1,5 +1,46 @@
+import { retrieveContext } from '@/lib/rag';
+import { loadEnvFiles } from '@/lib/load-env';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
 export async function POST(req: Request) {
-    const { messages } = await req.json();
+    const body = await req.json();
+    const { messages, documentIds } = body;
+    
+    // 🔎 DIAGNOSTIC: Print EVERY key in the body to find where documentIds goes
+    console.log("\n🔎 FULL BODY KEYS:", Object.keys(body));
+    console.log("🔎 documentIds:", documentIds);
+    
+    const lastMessage = messages[messages.length - 1];
+    
+    // Quick local verification: Fetch RAG chunks
+    if (lastMessage && lastMessage.role === 'user') {
+        try {
+            loadEnvFiles();
+            
+            // Get the authenticated user's access token so RLS works correctly
+            const cookieStore = await cookies();
+            const supabase = createServerClient(
+                process.env.NEXT_PUBLIC_SUPABASE_URL!,
+                process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+                { cookies: { getAll: () => cookieStore.getAll() } }
+            );
+            const { data: { session } } = await supabase.auth.getSession();
+            const accessToken = session?.access_token;
+            
+            console.log("\n=======================================================");
+            console.log("🔍 FETCHING RAG CONTEXT FOR: ", lastMessage.content);
+            console.log("📄 USING DOCUMENT IDS: ", documentIds);
+            console.log("🔑 HAS ACCESS TOKEN: ", !!accessToken);
+            const context = await retrieveContext(lastMessage.content, documentIds || [], accessToken);
+
+            console.log("==================== RESULTS ==========================");
+            console.log(context || "No relevant chunks found.");
+            console.log("=======================================================\n");
+        } catch (e) {
+            console.error("RAG Test Error:", e);
+        }
+    }
 
     // Check if this is the first interaction
     const isFirstMessage = !messages || messages.length === 0;

--- a/apps/web/app/sessions/[sessionId]/page.tsx
+++ b/apps/web/app/sessions/[sessionId]/page.tsx
@@ -144,7 +144,10 @@ export default function SessionPage() {
 
                     {/* Chat area */}
                     {!loading && !error && session ? (
-                        <ChatContainer sessionId={sessionId} />
+                        <ChatContainer 
+                            sessionId={sessionId} 
+                            documentIds={documents.map(d => d.document_id)} 
+                        />
                     ) : (
                         <div
                             style={{

--- a/apps/web/components/chat/ChatContainer.tsx
+++ b/apps/web/components/chat/ChatContainer.tsx
@@ -5,12 +5,16 @@ import { useEffect, useRef, useState } from 'react';
 import { ChatMessage } from './ChatMessage';
 import { ChatInput } from './ChatInput';
 
-export function ChatContainer({ sessionId }: { sessionId: string }) {
+export function ChatContainer({ sessionId, documentIds }: { sessionId: string; documentIds: string[] }) {
     const [input, setInput] = useState('');
+    
+    // useRef ensures the fetch interceptor always reads the LATEST documentIds,
+    // even though useChat's closure is only created once on mount.
+    const documentIdsRef = useRef<string[]>(documentIds);
+    useEffect(() => { documentIdsRef.current = documentIds; }, [documentIds]);
 
     const { messages, sendMessage, status } = useChat({
         api: '/api/chat',
-        body: { sessionId },
         initialMessages: [
             {
                 id: 'opening-msg',
@@ -35,8 +39,11 @@ export function ChatContainer({ sessionId }: { sessionId: string }) {
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         if (!input.trim() || isLoading) return;
-        // The newest Vercel AI SDK uses 'sendMessage' instead of 'append' or 'handleSubmit'!
-        sendMessage({ role: 'user', content: input.trim() });
+        // sendMessage's second arg (ChatRequestOptions) has a body field — use it!
+        void sendMessage(
+            { role: 'user', content: input.trim() },
+            { body: { sessionId, documentIds: documentIdsRef.current } }
+        );
         setInput('');
     };
 

--- a/apps/web/lib/embedder.ts
+++ b/apps/web/lib/embedder.ts
@@ -129,3 +129,24 @@ export async function embedChunksStrict(chunks: Chunk[]): Promise<EmbeddedChunk[
 
     return embedded;
 }
+
+// ---------------------------------------------------------------------------
+// Single query embedder (for RAG chat pipeline)
+// ---------------------------------------------------------------------------
+
+export async function embedQuery(query: string): Promise<number[]> {
+    const useMock = process.env.EMBEDDING_MOCK === "true";
+
+    if (useMock) {
+        console.warn("[embedder] EMBEDDING_MOCK=true — using fake vectors for query.");
+        return mockEmbedding(query);
+    }
+
+    const embeddings = await fetchEmbeddings([query]);
+    
+    if (!embeddings[0] || embeddings[0].length !== EMBEDDING_DIM) {
+        throw new Error(`Query embedding failed or dimension mismatch: expected ${EMBEDDING_DIM}, got ${embeddings[0]?.length}`);
+    }
+    
+    return embeddings[0];
+}

--- a/apps/web/lib/rag.ts
+++ b/apps/web/lib/rag.ts
@@ -1,0 +1,79 @@
+import { createClient } from '@supabase/supabase-js';
+import * as embedder from './embedder';
+import { loadEnvFiles } from './load-env';
+
+/**
+ * Initializes a secure Supabase client.
+ * If an accessToken is provided, it acts on behalf of the user (RLS enforced).
+ */
+export function getSupabaseClient(accessToken?: string) {
+    loadEnvFiles();
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    if (!url) throw new Error('NEXT_PUBLIC_SUPABASE_URL is missing.');
+    
+    if (accessToken) {
+        const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+        if (!anonKey) throw new Error('NEXT_PUBLIC_SUPABASE_ANON_KEY is missing.');
+        return createClient(url, anonKey, {
+            auth: { persistSession: false, autoRefreshToken: false },
+            global: { headers: { Authorization: `Bearer ${accessToken}` } },
+        });
+    } else {
+        // No token provided — intentional for trusted server-side callers (e.g. API routes)
+        // that have already verified the user's identity via cookies/session separately.
+        // RLS policies still apply: an unauthenticated anon client will return 0 rows
+        // for protected tables, so always pass accessToken in production code paths.
+        const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+        if (!anonKey) throw new Error('NEXT_PUBLIC_SUPABASE_ANON_KEY is missing.');
+        return createClient(url, anonKey, {
+            auth: { persistSession: false, autoRefreshToken: false },
+        });
+    }
+}
+
+/**
+ * Retrieves the most semantically relevant textbook chunks for a given query.
+ * 
+ * @param query The user's chat message
+ * @param documentIds The IDs of the documents belonging to this session
+ * @param accessToken The user's auth token to enforce Row Level Security
+ * @param matchCount The number of top chunks to return
+ * @returns A formatted markdown string of context
+ */
+export async function retrieveContext(
+    query: string,
+    documentIds: string[],
+    accessToken?: string,
+    matchCount = 5
+): Promise<string> {
+    if (documentIds.length === 0) return '';
+
+    // 1. Vectorize the user's query
+    const embedding = await embedder.embedQuery(query);
+
+    // 2. Query the database securely using the RPC function
+    const supabase = getSupabaseClient(accessToken);
+    
+    const { data: chunks, error } = await supabase.rpc('match_document_chunks', {
+        // pgvector functions often prefer raw arrays or stringified JSON arrays
+        query_embedding: JSON.stringify(embedding),
+        match_count: matchCount,
+        filter_document_ids: documentIds
+    });
+
+    if (error) {
+        console.error('RAG Retrieval Error:', error);
+        throw new Error(`Failed to retrieve document chunks: ${error.message}`);
+    }
+
+    if (!chunks || chunks.length === 0) {
+        return '';
+    }
+
+    // 3. Format the returned chunks into a readable string for the LLM
+    const formattedContext = chunks.map((chunk: any) => {
+        return `[Source Context (Similarity: ${(chunk.similarity * 100).toFixed(1)}%)]:\n${chunk.content}`;
+    }).join('\n\n---\n\n');
+
+    return formattedContext;
+}

--- a/supabase/migrations/0007_match_document_chunks.sql
+++ b/supabase/migrations/0007_match_document_chunks.sql
@@ -1,0 +1,29 @@
+-- ── 0007_match_document_chunks.sql ───────────────────────────────────────────
+-- Creates an RPC function to perform cosine similarity search on document chunks.
+-- This function is used by the RAG pipeline to retrieve relevant context.
+
+create or replace function match_document_chunks (
+  query_embedding vector,
+  match_count int,
+  filter_document_ids uuid[]
+) returns table (
+  chunk_id uuid,
+  document_id uuid,
+  content text,
+  similarity float
+)
+language plpgsql
+as $$
+begin
+  return query
+  select
+    document_chunks.chunk_id,
+    document_chunks.document_id,
+    document_chunks.content,
+    1 - (document_chunks.embedding <=> query_embedding) as similarity
+  from document_chunks
+  where document_chunks.document_id = any(filter_document_ids)
+  order by document_chunks.embedding <=> query_embedding
+  limit match_count;
+end;
+$$;

--- a/tests/rag.test.ts
+++ b/tests/rag.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, mock, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import * as rag from '../apps/web/lib/rag';
+
+describe('RAG Pipeline', () => {
+    afterEach(() => {
+        mock.restoreAll();
+    });
+
+    it('returns empty string if no documentIds are provided', async () => {
+        const result = await rag.retrieveContext('What is mitosis?', []);
+        assert.equal(result, '');
+    });
+
+    it('retrieves and formats chunks correctly from the database', async () => {
+        // Mock global.fetch to intercept both the Gemini API and Supabase RPC calls
+        const mockFetch = mock.method(global, 'fetch', async (url: string | URL | Request, options: any) => {
+            const urlString = url.toString();
+            
+            // Intercept Gemini Embedding API
+            if (urlString.includes('generativelanguage.googleapis.com')) {
+                return new Response(JSON.stringify({
+                    embeddings: [{ values: Array(3072).fill(0.1) }]
+                }), { status: 200 });
+            }
+
+            // Intercept Supabase RPC call
+            if (urlString.includes('/rest/v1/rpc/match_document_chunks')) {
+                return new Response(JSON.stringify([
+                    { content: 'Mitosis is cellular division.', similarity: 0.95 },
+                    { content: 'It results in two identical cells.', similarity: 0.88 }
+                ]), { 
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' }
+                });
+            }
+
+            throw new Error(`Unexpected fetch call: ${urlString}`);
+        });
+
+        // Set fake environment variables for the test
+        process.env.GEMINI_API_KEY = 'fake-gemini-key';
+        process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://fake-supabase-url.supabase.co';
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'fake-anon-key';
+
+        const result = await rag.retrieveContext('What is mitosis?', ['doc-1'], 'fake-token');
+
+        assert.equal(mockFetch.mock.callCount(), 2);
+        
+        // Check formatting
+        const expected = `[Source Context (Similarity: 95.0%)]:\nMitosis is cellular division.\n\n---\n\n[Source Context (Similarity: 88.0%)]:\nIt results in two identical cells.`;
+        assert.equal(result, expected);
+    });
+
+    it('returns empty string if no chunks match', async () => {
+        mock.method(global, 'fetch', async (url: string | URL | Request) => {
+            const urlString = url.toString();
+            if (urlString.includes('generativelanguage.googleapis.com')) {
+                return new Response(JSON.stringify({ embeddings: [{ values: Array(3072).fill(0.1) }] }), { status: 200 });
+            }
+            if (urlString.includes('/rest/v1/rpc/match_document_chunks')) {
+                return new Response(JSON.stringify([]), { status: 200 });
+            }
+            throw new Error(`Unexpected fetch call: ${urlString}`);
+        });
+
+        const result = await rag.retrieveContext('What is irrelevant?', ['doc-1'], 'fake-token');
+        assert.equal(result, '');
+    });
+});


### PR DESCRIPTION
This PR implements the core RAG (Retrieval-Augmented Generation) retrieval pipeline, enabling the backend to semantically search a student's uploaded document chunks and retrieve the most relevant context before generating a response. It strictly prepares the AI layer for real LLM integration in the upcoming orchestrator phase.

**Changes introduced:**
- `supabase/migrations/0007_match_document_chunks.sql`: Added a Postgres RPC function `match_document_chunks` that performs cosine similarity search using `pgvector`'s `<=>` operator, filtered by `document_ids[]`, and ordered by semantic relevance. Built on top of the IVFFlat index from migration `0005`.
- `apps/web/lib/embedder.ts`: Exported a new `embedQuery(query)` function for single-query embedding generation using `gemini-embedding-004` at 3072 dimensions. Intentionally bypasses the bulk batching logic used for document uploads.
- `apps/web/lib/rag.ts`: Created the RAG service module. `retrieveContext()` embeds the user's query, calls the `match_document_chunks` RPC with the user's JWT (to enforce Row Level Security), and formats the top-K results as a Markdown context string ready for LLM consumption.
- `apps/web/app/sessions/[sessionId]/page.tsx`: Wired `documentIds` from the session API response down into `ChatContainer`, ensuring the correct document scope is available for retrieval at the time of the first render.
- `apps/web/components/chat/ChatContainer.tsx`: Extended to accept `documentIds` as a prop. Implemented a `useRef` live-reference pattern to prevent stale closure issues, and passes `documentIds` to the backend via `sendMessage`'s `ChatRequestOptions.body` second argument — the correct per-request injection API in `@ai-sdk/react` v3.
- `apps/web/app/api/chat/route.ts`: Added a proof-of-life RAG verification block. Extracts the authenticated user's JWT from request cookies via `createServerClient` (required to satisfy RLS policies on `document_chunks`), then calls `retrieveContext()` and logs retrieved chunks to the terminal for dev verification.
- `tests/rag.test.ts`: Added 3 unit tests (3/3 passing) using Node's native `node:test` framework with mocked `global.fetch` to simulate both Gemini embedding calls and Supabase RPC responses.

**Related Issues:** Fixes #26 