### PR TITLE
Feat/quiz generation backend

### DIFF
--- a/apps/web/app/api/quiz/[quizId]/submit/route.ts
+++ b/apps/web/app/api/quiz/[quizId]/submit/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { submitQuiz } from '@/lib/quiz';
+import { loadEnvFiles } from '@/lib/load-env';
+
+export async function POST(
+    req: Request,
+    { params }: { params: Promise<{ quizId: string }> },
+) {
+    loadEnvFiles();
+
+    const cookieStore = await cookies();
+    const supabase = createServerClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        { cookies: { getAll: () => cookieStore.getAll() } },
+    );
+
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { quizId } = await params;
+    const body = await req.json();
+    const { answers } = body;
+
+    if (!answers || !Array.isArray(answers)) {
+        return NextResponse.json({ error: 'answers array is required.' }, { status: 400 });
+    }
+
+    try {
+        const result = await submitQuiz({
+            quizId,
+            answers,
+            accessToken: session.access_token,
+        });
+
+        return NextResponse.json(result);
+    } catch (err) {
+        console.error('[Quiz Submit]', err);
+        return NextResponse.json(
+            { error: err instanceof Error ? err.message : 'Quiz submission failed.' },
+            { status: 500 },
+        );
+    }
+}

--- a/apps/web/app/api/quiz/generate/route.ts
+++ b/apps/web/app/api/quiz/generate/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { generateQuiz } from '@/lib/quiz';
+import { loadEnvFiles } from '@/lib/load-env';
+
+export async function POST(req: Request) {
+    loadEnvFiles();
+
+    const cookieStore = await cookies();
+    const supabase = createServerClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        { cookies: { getAll: () => cookieStore.getAll() } },
+    );
+
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const { documentId, questionCount } = body;
+
+    if (!documentId || ![5, 10, 20].includes(questionCount)) {
+        return NextResponse.json(
+            { error: 'documentId and questionCount (5, 10, or 20) are required.' },
+            { status: 400 },
+        );
+    }
+
+    try {
+        const result = await generateQuiz({
+            documentId,
+            userId: session.user.id,
+            questionCount: questionCount as 5 | 10 | 20,
+            accessToken: session.access_token,
+        });
+
+        return NextResponse.json(result);
+    } catch (err) {
+        console.error('[Quiz Generate]', err);
+        return NextResponse.json(
+            { error: err instanceof Error ? err.message : 'Quiz generation failed.' },
+            { status: 500 },
+        );
+    }
+}

--- a/apps/web/components/chat/ChatContainer.tsx
+++ b/apps/web/components/chat/ChatContainer.tsx
@@ -3,6 +3,7 @@
 import { useChat } from '@ai-sdk/react';
 import type { UIMessage as Message } from 'ai';
 import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { ChatMessage } from './ChatMessage';
 import { ChatInput } from './ChatInput';
 
@@ -16,6 +17,7 @@ export function ChatContainer({
     initialMessages?: Message[];
 }) {
     const [input, setInput] = useState('');
+    const router = useRouter();
     
     // useRef ensures the fetch interceptor always reads the LATEST documentIds,
     // even though useChat's closure is only created once on mount.
@@ -56,7 +58,6 @@ export function ChatContainer({
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         if (!input.trim() || isLoading) return;
-        // sendMessage's second arg (ChatRequestOptions) has a body field — use it!
         void sendMessage(
             { role: 'user', content: input.trim() } as any,
             { body: { sessionId, documentIds: documentIdsRef.current } }
@@ -71,7 +72,7 @@ export function ChatContainer({
             flexDirection: 'column',
             overflow: 'hidden',
         }}>
-            {/* Header bar from your prototype */}
+            {/* Header bar */}
             <div style={{
                 padding: '14px 24px',
                 borderBottom: '1px solid var(--b1)',
@@ -93,6 +94,26 @@ export function ChatContainer({
                 }}>
                     Socratic mode
                 </div>
+                <div style={{ flex: 1 }} />
+                <button
+                    onClick={() => router.push(`/sessions/${sessionId}/quiz`)}
+                    style={{
+                        fontSize: 12,
+                        fontWeight: 500,
+                        color: 'var(--acc1)',
+                        background: 'var(--acl)',
+                        border: '1px solid var(--acl2)',
+                        borderRadius: 8,
+                        padding: '5px 12px',
+                        cursor: 'pointer',
+                        fontFamily: 'inherit',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 5,
+                    }}
+                >
+                    📝 Generate quiz
+                </button>
             </div>
 
             {/* Messages Area */}

--- a/apps/web/lib/quiz.ts
+++ b/apps/web/lib/quiz.ts
@@ -1,0 +1,259 @@
+import { createClient } from '@supabase/supabase-js';
+import { loadEnvFiles } from './load-env';
+import { z } from 'zod';
+
+// ── Zod schemas ────────────────────────────────────────────────────────────────
+
+const QuizQuestionSchema = z.object({
+    type: z.enum(['multiple_choice', 'short_answer', 'true_false']),
+    question: z.string().min(1),
+    options: z.array(z.string()).optional(),
+    correct_answer: z.string().min(1),
+    explanation: z.string().min(1),
+});
+
+const QuizResponseSchema = z.object({
+    questions: z.array(QuizQuestionSchema),
+});
+
+export type QuizQuestion = z.infer<typeof QuizQuestionSchema>;
+
+export type QuizQuestionRow = QuizQuestion & {
+    question_id: string;
+    quiz_id: string;
+    user_answer: string | null;
+    is_correct: boolean | null;
+};
+
+export type QuizRow = {
+    quiz_id: string;
+    user_id: string;
+    document_id: string;
+    question_count: number;
+    score: number | null;
+    created_at: string;
+};
+
+// ── Supabase client ────────────────────────────────────────────────────────────
+
+function getSupabaseClient(accessToken?: string) {
+    loadEnvFiles();
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+    return createClient(url, anonKey, {
+        auth: { persistSession: false, autoRefreshToken: false },
+        ...(accessToken && {
+            global: { headers: { Authorization: `Bearer ${accessToken}` } },
+        }),
+    });
+}
+
+// ── Quiz generation ────────────────────────────────────────────────────────────
+
+export async function generateQuiz({
+    documentId,
+    userId,
+    questionCount,
+    accessToken,
+}: {
+    documentId: string;
+    userId: string;
+    questionCount: 5 | 10 | 20;
+    accessToken: string;
+}): Promise<{ quizId: string; questions: QuizQuestionRow[] }> {
+    loadEnvFiles();
+    const supabase = getSupabaseClient(accessToken);
+
+    // 1. Fetch diverse chunks from the document
+    const { data: chunks, error: chunkError } = await supabase
+        .from('document_chunks')
+        .select('content, chunk_index')
+        .eq('document_id', documentId)
+        .order('chunk_index', { ascending: true })
+        .limit(5);
+
+    if (chunkError) throw new Error(`Failed to fetch chunks: ${chunkError.message}`);
+    if (!chunks || chunks.length === 0) throw new Error('No content found for this document.');
+
+    // Sample evenly across the document for diversity
+    const step = Math.max(1, Math.floor(chunks.length / questionCount));
+    const sampledChunks = chunks.filter((_, i) => i % step === 0).slice(0, questionCount * 2);
+    const contextText = sampledChunks.map((c) => c.content).join('\n\n---\n\n');
+
+    // 2. Call Groq Llama 3 8B
+    const prompt = `You are a quiz generator. Based on the following study material, generate exactly ${questionCount} quiz questions.
+
+Use a mix of question types:
+- multiple_choice: provide exactly 4 options as an array with full text (not letters), correct_answer must be the FULL TEXT of the correct option, not a letter like "A" or "B"
+- true_false: options should be ["True", "False"], correct_answer is "True" or "False"
+- short_answer: no options field, correct_answer is a brief phrase
+
+For each question, include a brief explanation citing the source material.
+
+Respond ONLY with a JSON object in this exact format, no markdown, no extra text:
+{
+  "questions": [
+    {
+      "type": "multiple_choice",
+      "question": "What is the capital of France?",
+      "options": ["London", "Paris", "Berlin", "Madrid"],
+      "correct_answer": "Paris",
+      "explanation": "Paris is the capital city of France."
+    },
+    {
+      "type": "true_false",
+      "question": "The sky is green.",
+      "options": ["True", "False"],
+      "correct_answer": "False",
+      "explanation": "The sky appears blue due to Rayleigh scattering."
+    },
+    {
+      "type": "short_answer",
+      "question": "What is the powerhouse of the cell?",
+      "correct_answer": "mitochondria",
+      "explanation": "The mitochondria produces energy for the cell."
+    }
+  ]
+}
+
+STUDY MATERIAL:
+${contextText}`;
+
+    const groqRes = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+        },
+        body: JSON.stringify({
+            model: 'llama-3.1-8b-instant',
+            messages: [{ role: 'user', content: prompt }],
+            temperature: 0.4,
+            max_tokens: 5000,
+        }),
+    });
+
+    if (!groqRes.ok) {
+        const err = await groqRes.text();
+        throw new Error(`Groq API error: ${err}`);
+    }
+
+    const groqData = await groqRes.json();
+    const rawText = groqData.choices?.[0]?.message?.content ?? '';
+
+    // 3. Parse and validate with Zod
+    let parsed: z.infer<typeof QuizResponseSchema>;
+    try {
+        const clean = rawText.replace(/```json|```/g, '').trim();
+        parsed = QuizResponseSchema.parse(JSON.parse(clean));
+    } catch {
+        throw new Error(`Quiz generation returned invalid JSON. Raw: ${rawText.slice(0, 300)}`);
+    }
+
+    const questions = parsed.questions.slice(0, questionCount);
+
+    // 4. Save quiz row
+    const { data: quizRow, error: quizError } = await supabase
+        .from('quizzes')
+        .insert({
+            user_id: userId,
+            document_id: documentId,
+            question_count: questions.length,
+        })
+        .select('quiz_id')
+        .single();
+
+    if (quizError || !quizRow) throw new Error(`Failed to save quiz: ${quizError?.message}`);
+
+    // 5. Save questions
+    const questionRows = questions.map((q) => ({
+        quiz_id: quizRow.quiz_id,
+        type: q.type,
+        question: q.question,
+        options: q.options ?? null,
+        correct_answer: q.correct_answer,
+        explanation: q.explanation,
+    }));
+
+    const { data: savedQuestions, error: qError } = await supabase
+        .from('quiz_questions')
+        .insert(questionRows)
+        .select('*');
+
+    if (qError || !savedQuestions) throw new Error(`Failed to save questions: ${qError?.message}`);
+
+    return {
+        quizId: quizRow.quiz_id,
+        questions: savedQuestions as QuizQuestionRow[],
+    };
+}
+
+// ── Quiz submission & grading ──────────────────────────────────────────────────
+
+export type AnswerSubmission = { questionId: string; userAnswer: string };
+
+export async function submitQuiz({
+    quizId,
+    answers,
+    accessToken,
+}: {
+    quizId: string;
+    answers: AnswerSubmission[];
+    accessToken: string;
+}): Promise<{
+    score: number;
+    total: number;
+    percentage: number;
+    results: {
+        question_id: string;
+        is_correct: boolean;
+        correct_answer: string;
+        explanation: string;
+        user_answer: string;
+    }[];
+}> {
+    const supabase = getSupabaseClient(accessToken);
+
+    const { data: questions, error: fetchErr } = await supabase
+        .from('quiz_questions')
+        .select('*')
+        .eq('quiz_id', quizId);
+
+    if (fetchErr || !questions) throw new Error(`Failed to fetch quiz: ${fetchErr?.message}`);
+
+    let score = 0;
+    const results = questions.map((q: QuizQuestionRow) => {
+        const submission = answers.find((a) => a.questionId === q.question_id);
+        const userAnswer = submission?.userAnswer ?? '';
+        const normalize = (s: string) =>
+            s.trim().toLowerCase().replace(/\s+/g, ' ').replace(/[^a-z0-9 ]/g, '');
+        const isCorrect = normalize(userAnswer) === normalize(q.correct_answer);
+        if (isCorrect) score++;
+        return {
+            question_id: q.question_id,
+            is_correct: isCorrect,
+            correct_answer: q.correct_answer,
+            explanation: q.explanation,
+            user_answer: userAnswer,
+        };
+    });
+
+    await Promise.all(
+        results.map((r) =>
+            supabase
+                .from('quiz_questions')
+                .update({ user_answer: r.user_answer, is_correct: r.is_correct })
+                .eq('question_id', r.question_id),
+        ),
+    );
+
+    await supabase.from('quizzes').update({ score }).eq('quiz_id', quizId);
+
+    return {
+        score,
+        total: questions.length,
+        percentage: Math.round((score / questions.length) * 100),
+        results,
+    };
+}

--- a/supabase/migrations/0009_quiz_schema.sql
+++ b/supabase/migrations/0009_quiz_schema.sql
@@ -1,0 +1,60 @@
+-- ── Quiz schema ───────────────────────────────────────────────────────────────
+
+create table if not exists public.quizzes (
+    quiz_id       uuid        primary key default gen_random_uuid(),
+    user_id       uuid        not null references public.users (user_id) on delete cascade,
+    document_id   uuid        not null references public.documents (document_id) on delete cascade,
+    question_count int        not null,
+    score         int,
+    created_at    timestamptz not null default now()
+);
+
+create table if not exists public.quiz_questions (
+    question_id   uuid        primary key default gen_random_uuid(),
+    quiz_id       uuid        not null references public.quizzes (quiz_id) on delete cascade,
+    type          text        not null check (type in ('multiple_choice', 'short_answer', 'true_false')),
+    question      text        not null,
+    options       jsonb,
+    correct_answer text       not null,
+    explanation   text        not null,
+    user_answer   text,
+    is_correct    boolean,
+    created_at    timestamptz not null default now()
+);
+
+-- RLS
+alter table public.quizzes       enable row level security;
+alter table public.quiz_questions enable row level security;
+
+create policy "quizzes: select own"
+    on public.quizzes for select using (auth.uid() = user_id);
+
+create policy "quizzes: insert own"
+    on public.quizzes for insert with check (auth.uid() = user_id);
+
+create policy "quizzes: update own"
+    on public.quizzes for update using (auth.uid() = user_id);
+
+create policy "quiz_questions: select via quiz"
+    on public.quiz_questions for select
+    using (exists (
+        select 1 from public.quizzes q
+        where q.quiz_id = quiz_questions.quiz_id
+          and q.user_id = auth.uid()
+    ));
+
+create policy "quiz_questions: insert via quiz"
+    on public.quiz_questions for insert
+    with check (exists (
+        select 1 from public.quizzes q
+        where q.quiz_id = quiz_questions.quiz_id
+          and q.user_id = auth.uid()
+    ));
+
+create policy "quiz_questions: update via quiz"
+    on public.quiz_questions for update
+    using (exists (
+        select 1 from public.quizzes q
+        where q.quiz_id = quiz_questions.quiz_id
+          and q.user_id = auth.uid()
+    ));

--- a/tests/quiz.test.ts
+++ b/tests/quiz.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, mock, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { generateQuiz, submitQuiz } from '../apps/web/lib/quiz';
+import ws from 'ws';
+(global as any).WebSocket = ws;
+
+// ── Shared fake env ────────────────────────────────────────────────────────────
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://fake.supabase.co';
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'fake-anon-key';
+process.env.GROQ_API_KEY = 'fake-groq-key';
+
+// ── Shared mock data ───────────────────────────────────────────────────────────
+
+const FAKE_CHUNKS = [
+    { content: 'Mitosis is cell division that produces two identical daughter cells.', chunk_index: 0 },
+    { content: 'Meiosis produces four genetically distinct haploid cells.', chunk_index: 1 },
+];
+
+const FAKE_QUESTIONS = [
+    {
+        question_id: 'q1',
+        quiz_id: 'quiz-1',
+        type: 'multiple_choice',
+        question: 'What does mitosis produce?',
+        options: ['Two identical cells', 'Four distinct cells', 'One cell', 'Three cells'],
+        correct_answer: 'Two identical cells',
+        explanation: 'Mitosis produces two identical daughter cells.',
+        user_answer: null,
+        is_correct: null,
+    },
+    {
+        question_id: 'q2',
+        quiz_id: 'quiz-1',
+        type: 'true_false',
+        question: 'Meiosis produces two cells.',
+        options: ['True', 'False'],
+        correct_answer: 'False',
+        explanation: 'Meiosis produces four haploid cells.',
+        user_answer: null,
+        is_correct: null,
+    },
+    {
+        question_id: 'q3',
+        quiz_id: 'quiz-1',
+        type: 'short_answer',
+        question: 'How many cells does meiosis produce?',
+        correct_answer: 'four',
+        explanation: 'Meiosis produces four genetically distinct haploid cells.',
+        user_answer: null,
+        is_correct: null,
+    },
+];
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+/** Builds a mock fetch that handles Supabase REST calls for generateQuiz */
+function mockFetchForGenerate(groqQuestions: object[]) {
+    return mock.method(global, 'fetch', async (url: string | URL | Request, options: any) => {
+        const urlString = url.toString();
+        const body = options?.body ? JSON.parse(options.body) : null;
+
+        // Supabase: fetch chunks
+        if (urlString.includes('/rest/v1/document_chunks')) {
+            return new Response(JSON.stringify(FAKE_CHUNKS), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+
+        // Groq: generate questions
+        if (urlString.includes('api.groq.com')) {
+            return new Response(
+                JSON.stringify({
+                    choices: [
+                        {
+                            message: {
+                                content: JSON.stringify({ questions: groqQuestions }),
+                            },
+                        },
+                    ],
+                }),
+                { status: 200, headers: { 'Content-Type': 'application/json' } },
+            );
+        }
+
+        // Supabase: insert quiz row
+        if (urlString.includes('/rest/v1/quizzes') && body) {
+            return new Response(JSON.stringify({ quiz_id: 'quiz-1' }), {
+                status: 201,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+
+        // Supabase: insert quiz_questions
+        if (urlString.includes('/rest/v1/quiz_questions')) {
+            return new Response(JSON.stringify(FAKE_QUESTIONS), {
+                status: 201,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+
+        throw new Error(`Unexpected fetch call: ${urlString}`);
+    });
+}
+
+// ── generateQuiz tests ─────────────────────────────────────────────────────────
+
+describe('generateQuiz', () => {
+    afterEach(() => {
+        mock.restoreAll();
+    });
+
+    it('returns a quizId and questions on success', async () => {
+        mockFetchForGenerate(FAKE_QUESTIONS);
+
+        const result = await generateQuiz({
+            documentId: 'doc-1',
+            userId: 'user-1',
+            questionCount: 5,
+            accessToken: 'fake-token',
+        });
+
+        assert.ok(result.quizId, 'should return a quizId');
+        assert.ok(Array.isArray(result.questions), 'questions should be an array');
+    });
+
+    it('throws if no chunks are found for the document', async () => {
+        mock.method(global, 'fetch', async (url: string | URL | Request) => {
+            if (url.toString().includes('/rest/v1/document_chunks')) {
+                return new Response(JSON.stringify([]), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+            throw new Error(`Unexpected fetch: ${url}`);
+        });
+
+        await assert.rejects(
+            () =>
+                generateQuiz({
+                    documentId: 'doc-empty',
+                    userId: 'user-1',
+                    questionCount: 5,
+                    accessToken: 'fake-token',
+                }),
+            /No content found/,
+        );
+    });
+
+    it('throws if Groq returns invalid JSON', async () => {
+        mock.method(global, 'fetch', async (url: string | URL | Request) => {
+            if (url.toString().includes('/rest/v1/document_chunks')) {
+                return new Response(JSON.stringify(FAKE_CHUNKS), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+            if (url.toString().includes('api.groq.com')) {
+                return new Response(
+                    JSON.stringify({
+                        choices: [{ message: { content: 'not valid json at all' } }],
+                    }),
+                    { status: 200, headers: { 'Content-Type': 'application/json' } },
+                );
+            }
+            throw new Error(`Unexpected fetch: ${url}`);
+        });
+
+        await assert.rejects(
+            () =>
+                generateQuiz({
+                    documentId: 'doc-1',
+                    userId: 'user-1',
+                    questionCount: 5,
+                    accessToken: 'fake-token',
+                }),
+            /invalid JSON/,
+        );
+    });
+
+    it('throws if Groq API returns an error status', async () => {
+        mock.method(global, 'fetch', async (url: string | URL | Request) => {
+            if (url.toString().includes('/rest/v1/document_chunks')) {
+                return new Response(JSON.stringify(FAKE_CHUNKS), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+            if (url.toString().includes('api.groq.com')) {
+                return new Response('rate limit exceeded', { status: 429 });
+            }
+            throw new Error(`Unexpected fetch: ${url}`);
+        });
+
+        await assert.rejects(
+            () =>
+                generateQuiz({
+                    documentId: 'doc-1',
+                    userId: 'user-1',
+                    questionCount: 5,
+                    accessToken: 'fake-token',
+                }),
+            /Groq API error/,
+        );
+    });
+});
+
+// ── submitQuiz tests ───────────────────────────────────────────────────────────
+
+describe('submitQuiz', () => {
+    afterEach(() => {
+        mock.restoreAll();
+    });
+
+    it('grades correct answers and returns the right score', async () => {
+        mock.method(global, 'fetch', async (url: string | URL | Request, options: any) => {
+            const urlString = url.toString();
+
+            // Fetch questions
+            if (urlString.includes('/rest/v1/quiz_questions') && options?.method !== 'PATCH') {
+                return new Response(JSON.stringify(FAKE_QUESTIONS), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+
+            // Update quiz_questions (user_answer + is_correct)
+            if (urlString.includes('/rest/v1/quiz_questions') && options?.method === 'PATCH') {
+                return new Response(JSON.stringify({}), { status: 200 });
+            }
+
+            // Update quizzes (score)
+            if (urlString.includes('/rest/v1/quizzes') && options?.method === 'PATCH') {
+                return new Response(JSON.stringify({}), { status: 200 });
+            }
+
+            throw new Error(`Unexpected fetch: ${urlString}`);
+        });
+
+        const result = await submitQuiz({
+            quizId: 'quiz-1',
+            answers: [
+                { questionId: 'q1', userAnswer: 'Two identical cells' }, // correct
+                { questionId: 'q2', userAnswer: 'False' },               // correct
+                { questionId: 'q3', userAnswer: 'four' },                // correct
+            ],
+            accessToken: 'fake-token',
+        });
+
+        assert.equal(result.score, 3);
+        assert.equal(result.total, 3);
+        assert.equal(result.percentage, 100);
+        assert.ok(result.results.every((r) => r.is_correct), 'all should be correct');
+    });
+
+    it('marks wrong answers as incorrect', async () => {
+        mock.method(global, 'fetch', async (url: string | URL | Request, options: any) => {
+            const urlString = url.toString();
+
+            if (urlString.includes('/rest/v1/quiz_questions') && options?.method !== 'PATCH') {
+                return new Response(JSON.stringify(FAKE_QUESTIONS), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+            if (urlString.includes('/rest/v1/quiz_questions') && options?.method === 'PATCH') {
+                return new Response(JSON.stringify({}), { status: 200 });
+            }
+            if (urlString.includes('/rest/v1/quizzes') && options?.method === 'PATCH') {
+                return new Response(JSON.stringify({}), { status: 200 });
+            }
+
+            throw new Error(`Unexpected fetch: ${urlString}`);
+        });
+
+        const result = await submitQuiz({
+            quizId: 'quiz-1',
+            answers: [
+                { questionId: 'q1', userAnswer: 'Four distinct cells' }, // wrong
+                { questionId: 'q2', userAnswer: 'True' },                // wrong
+                { questionId: 'q3', userAnswer: 'two' },                 // wrong
+            ],
+            accessToken: 'fake-token',
+        });
+
+        assert.equal(result.score, 0);
+        assert.equal(result.percentage, 0);
+        assert.ok(result.results.every((r) => !r.is_correct), 'all should be incorrect');
+    });
+
+    it('handles partial answers gracefully', async () => {
+        mock.method(global, 'fetch', async (url: string | URL | Request, options: any) => {
+            const urlString = url.toString();
+
+            if (urlString.includes('/rest/v1/quiz_questions') && options?.method !== 'PATCH') {
+                return new Response(JSON.stringify(FAKE_QUESTIONS), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+            if (urlString.includes('/rest/v1/quiz_questions') && options?.method === 'PATCH') {
+                return new Response(JSON.stringify({}), { status: 200 });
+            }
+            if (urlString.includes('/rest/v1/quizzes') && options?.method === 'PATCH') {
+                return new Response(JSON.stringify({}), { status: 200 });
+            }
+
+            throw new Error(`Unexpected fetch: ${urlString}`);
+        });
+
+        // Only answer one out of three questions
+        const result = await submitQuiz({
+            quizId: 'quiz-1',
+            answers: [
+                { questionId: 'q1', userAnswer: 'Two identical cells' }, // correct
+            ],
+            accessToken: 'fake-token',
+        });
+
+        assert.equal(result.score, 1);
+        assert.equal(result.total, 3);
+        assert.equal(result.percentage, 33);
+    });
+
+    it('is case-insensitive when grading answers', async () => {
+        mock.method(global, 'fetch', async (url: string | URL | Request, options: any) => {
+            const urlString = url.toString();
+
+            if (urlString.includes('/rest/v1/quiz_questions') && options?.method !== 'PATCH') {
+                return new Response(JSON.stringify(FAKE_QUESTIONS), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+            if (urlString.includes('/rest/v1/quiz_questions') && options?.method === 'PATCH') {
+                return new Response(JSON.stringify({}), { status: 200 });
+            }
+            if (urlString.includes('/rest/v1/quizzes') && options?.method === 'PATCH') {
+                return new Response(JSON.stringify({}), { status: 200 });
+            }
+
+            throw new Error(`Unexpected fetch: ${urlString}`);
+        });
+
+        const result = await submitQuiz({
+            quizId: 'quiz-1',
+            answers: [
+                { questionId: 'q3', userAnswer: 'FOUR' }, // uppercase, should still match
+            ],
+            accessToken: 'fake-token',
+        });
+
+        const q3Result = result.results.find((r) => r.question_id === 'q3');
+        assert.ok(q3Result?.is_correct, 'should be case-insensitive');
+    });
+});


### PR DESCRIPTION
This PR implements the quiz generation and grading backend for Feature-3.

**Changes**
- `supabase/migrations/0009_quiz_schema.sql` -- adds `quizzes` and `quiz_questions` tables with RLS policies
- `apps/web/lib/quiz.ts` -- core logic for generating quizzes using Groq Llama 3.1 8B, grounded in document chunks, validated with Zod
- `apps/web/app/api/quiz/generate/route.ts` -- POST /api/quiz/generate endpoint
- `apps/web/app/api/quiz/[quizId]/submit/route.ts` -- POST /api/quiz/[quizId]/submit endpoint for grading
- `apps/web/components/chat/ChatContainer.tsx` -- added "Generate quiz" button in chat header

**Tests**
8 unit tests covering:
- Successful quiz generation
- Empty document handling
- Invalid JSON from Groq
- Groq API error handling
- Correct answer grading
- Wrong answer grading
- Partial submission handling
- Case-insensitive grading